### PR TITLE
File path addition done using file object rather than manipulating string.

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -16,7 +16,7 @@ module Octopus
 
   def self.config
     @config ||= begin
-      file_name = Octopus.directory + '/config/shards.yml'
+      file_name = File.join(Octopus.directory,'config/shards.yml').to_s
 
       if File.exist?(file_name) || File.symlink?(file_name)
         config ||= HashWithIndifferentAccess.new(YAML.load(ERB.new(File.read(file_name)).result))[Octopus.env]


### PR DESCRIPTION
Rather than using a string manipulation operation, having a file object to join paths. 
It is also recommended because this can give user power to define his own directory from where shards settings should be picked up.