### PR TITLE
Update touch arguments

### DIFF
--- a/lib/octopus/persistence.rb
+++ b/lib/octopus/persistence.rb
@@ -25,7 +25,7 @@ module Octopus
         run_on_shard { super }
       end
 
-      def touch(name = nil)
+      def touch(*args)
         run_on_shard { super }
       end
 


### PR DESCRIPTION
ActiveRecord 4.2 changed the method arguments, which breaks when having octopus.

https://github.com/rails/rails/commit/c80ca4c7803b4e8ed7f125ada9acc6b7c499af5f