### PR TITLE
Do not replicate model if self.replicated = false

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,7 @@ namespace :db do
     require 'octopus'
     # Set the octopus variable directory to spec dir, in order to load the config/shards.yml file.
     Octopus.instance_variable_set(:@directory, "#{File.dirname(__FILE__)}/spec/")
+    Octopus.instance_variable_set(:@config, nil)
 
     # Require the database connection
     require "#{File.dirname(__FILE__)}/spec/support/database_connection"

--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -46,7 +46,7 @@ module Octopus
   # Returns the Rails.root_to_s when you are using rails
   # Running the current directory in a generic Ruby process
   def self.directory
-    @directory ||= defined?(Rails) ?  Rails.root.to_s : Dir.pwd
+    @directory ||= (defined?(Rails) && Rails.root) ? Rails.root.to_s : Dir.pwd
   end
 
   # This is the default way to do Octopus Setup

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -79,6 +79,7 @@ module Octopus
         base.class_attribute(:sharded)
         base.class_attribute(:allowed_shards)
         base.hijack_methods
+        base.replicated = Octopus.enabled? if base.replicated.nil?
       end
 
       def replicated_model
@@ -124,7 +125,7 @@ module Octopus
       end
 
       def should_use_normal_connection?
-        if !Octopus.enabled?
+        if !Octopus.enabled? || !replicated
           true
         elsif custom_octopus_connection
           !connection_proxy.block || !allowed_shard?(connection_proxy.current_shard)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 require 'octopus'
 
 Octopus.instance_variable_set(:@directory, File.dirname(__FILE__))
+Octopus.instance_variable_set(:@config, nil)
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.


### PR DESCRIPTION
Hi,

I have `Octopus` gem configured something like:
```yaml
# shads.yml
octopus:
  replicated: false
  fully_replicated: false
  environments:
    - production
  ...
```

And I have a model, for example:
```ruby
class Foo < ActiveRecord::Base
  establish_connection(CUSTOM_SETTINGS)
end
```

So I am wondering why Octopus uses `Octopus::Proxy` for that model instead of my custom connection when I have turned off replication and haven't set `replicated_model` for `Foo`. Can we check is model replicated in `should_use_normal_connection?` method?

Currently there are some tests failed, I can fix them if you are agree to add this changes :smile: 

Thanks!