### PR TITLE
Fix stack level too deep on grouped calculation

### DIFF
--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.2.0'
 
   s.add_development_dependency 'appraisal', '>= 0.3.8'
-  s.add_development_dependency 'mysql2', '> 0.3'
+  s.add_development_dependency 'mysql2', '~> 0.3.18'
   s.add_development_dependency 'pg', '>= 0.11.0'
   s.add_development_dependency 'rake', '>= 0.8.7'
   s.add_development_dependency 'rspec', '>= 3'

--- a/lib/octopus/association_shard_tracking.rb
+++ b/lib/octopus/association_shard_tracking.rb
@@ -26,8 +26,8 @@ module Octopus
 
       METHODS.each do |m|
         define_method m.to_sym do |*args, &block|
-          if self.respond_to?(:proxy_association) && proxy_association
-            proxy_association.owner.run_on_shard { super(*args, &block) }
+          if defined?(@association) && @association
+            @association.owner.run_on_shard { super(*args, &block) }
           else
             super(*args, &block)
           end

--- a/spec/octopus/association_shard_tracking_spec.rb
+++ b/spec/octopus/association_shard_tracking_spec.rb
@@ -630,6 +630,12 @@ describe Octopus::AssociationShardTracking, :shards => [:brazil, :master, :canad
         expect(@brazil_client.comments.count).to eq(2)
       end
 
+      it 'group + count' do
+        expect(@brazil_client.comments.group(:id).count.length).to eq(1)
+        _cmt = @brazil_client.comments.create(:name => 'Builded Comment')
+        expect(@brazil_client.comments.group(:id).count.length).to eq(2)
+      end
+
       it 'size' do
         expect(@brazil_client.comments.size).to eq(1)
         _cmt = @brazil_client.comments.create(:name => 'Builded Comment')


### PR DESCRIPTION
Here's an attempt to fix #322 

This stack level too deep error happens when `respond_to?` being called on unloaded grouped AR::Relation.
This patch changes the code to directly reference the instance variable `@association` rather than using a public method.
This approach is indeed a little bit adhoc, but this should work on [AR 5](https://github.com/rails/rails/blob/bf4f739e0793c048cdba02e46c76fe2f46202da4/activerecord/lib/active_record/association_relation.rb#L8-L10), [4.2](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/association_relation.rb#L8-L10), [4.1](https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/association_relation.rb#L8-L10), [4.0](https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/association_relation.rb#L8-L10), and [3.2](https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/associations/collection_proxy.rb#L60-L62).

The 2nd commit in this PR was needed to run the test. Tell me if I should not add it here and I'd better create another PR for that.